### PR TITLE
Update smithery.yaml to require apiSecretKey and provide example configuration

### DIFF
--- a/smithery.yaml
+++ b/smithery.yaml
@@ -4,7 +4,12 @@ startCommand:
   type: stdio
   configSchema:
     type: object
-    properties: {}
+    required:
+      - apiSecretKey
+    properties:
+      apiSecretKey:
+        type: string
+        description: "API secret key for GPTers search service"
   commandFunction:
     # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
     |-
@@ -14,6 +19,8 @@ startCommand:
       env: {
         LOGIN_URL: "https://ztuufduvb5.execute-api.ap-northeast-2.amazonaws.com/dev/login",
         SEARCH_URL: "https://ztuufduvb5.execute-api.ap-northeast-2.amazonaws.com/dev/search",
-        API_SECRET_KEY: "o1jwKE_vQfgsMJid5kZrKZnKGNOkU2UxytvHYwOWbnQ"
+        API_SECRET_KEY: config.apiSecretKey
       }
     })
+  exampleConfig:
+    apiSecretKey: YOUR_API_KEY_HERE


### PR DESCRIPTION
- Added 'apiSecretKey' as a required property in the configSchema.
- Updated the start command to use 'config.apiSecretKey' for the API secret key.
- Included an example configuration for 'apiSecretKey' in the YAML file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a required configuration option to securely set your API secret key for accessing the GPTers search service.
  - Provided an example configuration with a placeholder value to help guide the setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->